### PR TITLE
Fix typo in MessageManager comment

### DIFF
--- a/Source/NPCForge/Public/MessageManager.h
+++ b/Source/NPCForge/Public/MessageManager.h
@@ -50,7 +50,7 @@ public:
     UFUNCTION(BlueprintCallable)
     TArray<FMessage> GetAllMessages() const;
 
-    // Get messages fo specific NPC
+    // Get messages for specific NPC
     UFUNCTION(BlueprintCallable)
     TArray<FMessage> GetMessagesForNPC(const FString& NPCChecksum) const;
 


### PR DESCRIPTION
## Summary
- correct comment in `MessageManager.h`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f8e8e4110832d947ddcff739c24cd