### PR TITLE
Handle WebSocket reconnections and re-registration

### DIFF
--- a/Source/NPCForge/Private/WebSocketHandler.cpp
+++ b/Source/NPCForge/Private/WebSocketHandler.cpp
@@ -1,232 +1,262 @@
 ﻿// Fill out your copyright notice in the Description page of Project Settings.
 
-
 #include "WebSocketHandler.h"
 
-void UWebSocketHandler::Initialize()
-{
-	Socket->OnConnected().AddLambda([]() -> void {
-		UE_LOG(LogTemp, Log, TEXT("[UWebSocketHandler::Initialize]: Connected"));
-	});
-    
-	Socket->OnConnectionError().AddLambda([](const FString & Error) -> void {
-		UE_LOG(LogTemp, Log, TEXT("[UWebSocketHandler::Initialize]: Connection error: %s"), *Error);
-	});
-    
-	Socket->OnClosed().AddLambda([](int32 StatusCode, const FString& Reason, bool bWasClean) -> void {
-		UE_LOG(LogTemp, Log, TEXT("[UWebSocketHandler::Initialize]: Connection closed: %s"), *Reason);
-	});
-    
-	Socket->OnMessage().AddLambda([this](const FString& Message) -> void {
-		HandleReceivedMessage(Message);
-	});
-    
-	Socket->OnRawMessage().AddLambda([](const void* Data, SIZE_T Size, SIZE_T BytesRemaining) -> void {
-	});
-    
-	Socket->OnMessageSent().AddLambda([](const FString& MessageString) -> void {
-	});
+void UWebSocketHandler::Initialize() {
+  Socket->OnConnected().AddLambda([this]() -> void {
+    UE_LOG(LogTemp, Log, TEXT("[UWebSocketHandler::Initialize]: Connected"));
 
-	Socket->Connect();
+    if (!bIsRegistered) {
+      RegisterAPI();
+    } else {
+      ConnectAPI();
+    }
+  });
+
+  Socket->OnConnectionError().AddLambda([this](const FString &Error) -> void {
+    UE_LOG(LogTemp, Log,
+           TEXT("[UWebSocketHandler::Initialize]: Connection error: %s"),
+           *Error);
+    bIsConnected = false;
+    Socket->Connect();
+  });
+
+  Socket->OnClosed().AddLambda(
+      [this](int32 StatusCode, const FString &Reason, bool bWasClean) -> void {
+        UE_LOG(LogTemp, Warning,
+               TEXT("[UWebSocketHandler::Initialize]: Connection closed: %s, "
+                    "attempting to reconnect"),
+               *Reason);
+        bIsConnected = false;
+        Socket->Connect();
+      });
+
+  Socket->OnMessage().AddLambda([this](const FString &Message) -> void {
+    HandleReceivedMessage(Message);
+  });
+
+  Socket->OnRawMessage().AddLambda(
+      [](const void *Data, SIZE_T Size, SIZE_T BytesRemaining) -> void {});
+
+  Socket->OnMessageSent().AddLambda(
+      [](const FString &MessageString) -> void {});
+
+  Socket->Connect();
 }
 
-void UWebSocketHandler::HandleReceivedMessage(const FString &Message)
-{
-	const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Message);
+void UWebSocketHandler::HandleReceivedMessage(const FString &Message) {
+  const TSharedRef<TJsonReader<>> Reader =
+      TJsonReaderFactory<>::Create(Message);
 
-	UE_LOG(LogTemp, Log, TEXT("[UAIComponent::HandleWebSocketMessage]: Raw message = %s"), *Message);
-	
-	if (TSharedPtr<FJsonObject> JsonObject;
-		FJsonSerializer::Deserialize(Reader, JsonObject) && JsonObject.IsValid())
-	{
-		if (JsonObject->GetStringField(TEXT("status")) == TEXT("error"))
-		{
-			OnMessageReceived.Broadcast(Message);
-			return;
-		}
-		for (const auto& Pair : JsonObject->Values)
-		{
-			FString Key = Pair.Key;
+  UE_LOG(LogTemp, Log,
+         TEXT("[UAIComponent::HandleWebSocketMessage]: Raw message = %s"),
+         *Message);
 
-			if (Pair.Value->Type == EJson::String)
-			{
-				FString Value = Pair.Value->AsString();
-				
-				if (Key == "route")
-				{
-					if (Value == "Register")
-					{
-						UE_LOG(LogTemp, Log, TEXT("[UAIComponent::HandleWebSocketMessage]: Handle Register Logic"));
-						SetToken(JsonObject->GetStringField(TEXT("token")));
-						ApiUserID = JsonObject->GetNumberField(TEXT("id"));
-						bIsRegistered = true;
-					}
-					else if (Value == "Connect")
-					{
-						UE_LOG(LogTemp, Log, TEXT("[UAIComponent::HandleWebSocketMessage]: Handle Connection Logic"));
-						SetToken(JsonObject->GetStringField(TEXT("token")));
-						ApiUserID = JsonObject->GetNumberField(TEXT("id"));
-					}
-					else if (Value == "GetEntities")
-					{
-						UE_LOG(LogTemp, Log, TEXT("[UAIComponent::HandleWebSocketMessage]: Handle GetEntities Logic"));
-						
-						if (JsonObject->HasTypedField<EJson::Array>(TEXT("entities")))
-						{
-							TArray<TSharedPtr<FJsonValue>> EntitiesArray;
-							EntitiesArray = JsonObject->GetArrayField(TEXT("entities"));
+  if (TSharedPtr<FJsonObject> JsonObject;
+      FJsonSerializer::Deserialize(Reader, JsonObject) &&
+      JsonObject.IsValid()) {
+    if (JsonObject->GetStringField(TEXT("status")) == TEXT("error")) {
+      OnMessageReceived.Broadcast(Message);
+      return;
+    }
+    for (const auto &Pair : JsonObject->Values) {
+      FString Key = Pair.Key;
 
-							for (const TSharedPtr<FJsonValue>& Val : EntitiesArray)
-							{
-								if (Val->Type == EJson::Object)
-								{
-									if (TSharedPtr<FJsonObject> EntityObject = Val->AsObject();
-										EntityObject.IsValid())
-									{
-										FString Id = EntityObject->GetStringField(TEXT("id"));
-										FString Checksum = EntityObject->GetStringField(TEXT("checksum"));
+      if (Pair.Value->Type == EJson::String) {
+        FString Value = Pair.Value->AsString();
 
-										UE_LOG(LogTemp, Log, TEXT("Entity ID: %s | Checksum: %s"), *Id, *Checksum);
+        if (Key == "route") {
+          if (Value == "Register") {
+            UE_LOG(LogTemp, Log,
+                   TEXT("[UAIComponent::HandleWebSocketMessage]: Handle "
+                        "Register Logic"));
+            SetToken(JsonObject->GetStringField(TEXT("token")));
+            ApiUserID = JsonObject->GetNumberField(TEXT("id"));
+            bIsRegistered = true;
+          } else if (Value == "Connect") {
+            UE_LOG(LogTemp, Log,
+                   TEXT("[UAIComponent::HandleWebSocketMessage]: Handle "
+                        "Connection Logic"));
+            SetToken(JsonObject->GetStringField(TEXT("token")));
+            ApiUserID = JsonObject->GetNumberField(TEXT("id"));
+          } else if (Value == "GetEntities") {
+            UE_LOG(LogTemp, Log,
+                   TEXT("[UAIComponent::HandleWebSocketMessage]: Handle "
+                        "GetEntities Logic"));
 
-										RegisterEntity(Checksum, Id);
-									}
-								}
-							}
-						}
-						else
-						{
-							UE_LOG(LogTemp, Warning, TEXT("No 'entities' array found or not of array type."));
-						}
+            if (JsonObject->HasTypedField<EJson::Array>(TEXT("entities"))) {
+              TArray<TSharedPtr<FJsonValue>> EntitiesArray;
+              EntitiesArray = JsonObject->GetArrayField(TEXT("entities"));
 
-						OnReady.Broadcast();
-					}
-					else if (Value == "CreateEntity")
-					{
-						UE_LOG(LogTemp, Log, TEXT("[UAIComponent::HandleWebSocketMessage]: Handle CreateEntity Logic"));
-						RegisterEntity(JsonObject->GetStringField(TEXT("checksum")), JsonObject->GetStringField(TEXT("id")));
-					} else
-					{
-						OnMessageReceived.Broadcast(Message);
-					}
-				}
-			}
-		}
-	}
-	else
-	{
-		UE_LOG(LogTemp, Error, TEXT("[NPCForge:WebSocketCommunication]: Failed to parse JSON: %s"), *Message);
-	}
+              for (const TSharedPtr<FJsonValue> &Val : EntitiesArray) {
+                if (Val->Type == EJson::Object) {
+                  if (TSharedPtr<FJsonObject> EntityObject = Val->AsObject();
+                      EntityObject.IsValid()) {
+                    FString Id = EntityObject->GetStringField(TEXT("id"));
+                    FString Checksum =
+                        EntityObject->GetStringField(TEXT("checksum"));
+
+                    UE_LOG(LogTemp, Log, TEXT("Entity ID: %s | Checksum: %s"),
+                           *Id, *Checksum);
+
+                    RegisterEntity(Checksum, Id);
+                  }
+                }
+              }
+            } else {
+              UE_LOG(LogTemp, Warning,
+                     TEXT("No 'entities' array found or not of array type."));
+            }
+
+            OnReady.Broadcast();
+          } else if (Value == "CreateEntity") {
+            UE_LOG(LogTemp, Log,
+                   TEXT("[UAIComponent::HandleWebSocketMessage]: Handle "
+                        "CreateEntity Logic"));
+            RegisterEntity(JsonObject->GetStringField(TEXT("checksum")),
+                           JsonObject->GetStringField(TEXT("id")));
+          } else {
+            OnMessageReceived.Broadcast(Message);
+          }
+        }
+      }
+    }
+  } else {
+    UE_LOG(LogTemp, Error,
+           TEXT("[NPCForge:WebSocketCommunication]: Failed to parse JSON: %s"),
+           *Message);
+  }
 }
 
-bool UWebSocketHandler::IsEntityRegistered(const FString& Checksum) const
-{
-	return RegisteredEntities.IsValid() && RegisteredEntities->Contains(Checksum);
+bool UWebSocketHandler::IsEntityRegistered(const FString &Checksum) const {
+  return RegisteredEntities.IsValid() && RegisteredEntities->Contains(Checksum);
 }
 
-void UWebSocketHandler::Close()
-{
-	DisconnectAPI();
-	Socket->Close();
+void UWebSocketHandler::Ping() {
+  if (Socket->IsConnected()) {
+    Socket->Ping();
+  } else {
+    UE_LOG(LogTemp, Warning,
+           TEXT("[UWebSocketHandler::Ping]: Socket not connected, attempting "
+                "to reconnect."));
+    Socket->Connect();
+  }
 }
 
-void UWebSocketHandler::SendMessage(const FString& Action, TSharedPtr<FJsonObject> JsonBody) const
-{
-	if (!JsonBody.IsValid())
-	{
-		JsonBody = MakeShareable(new FJsonObject());
-	}
-	JsonBody->SetStringField("action", Action);
-	JsonBody->SetStringField("token", Token);
-
-	FString OutputString;
-	if (const TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
-		FJsonSerializer::Serialize(JsonBody.ToSharedRef(), Writer)) {
-		Socket->Send(OutputString);
-		UE_LOG(LogTemp, Log, TEXT("[UWebSocketHandler::SendMessage]: JSON message sent: %s"), *OutputString);
-	} else
-	{
-		UE_LOG(LogTemp, Error, TEXT("[UWebSocketHandler::SendMessage]: Failed to serialize JSON"));
-	}
+void UWebSocketHandler::Close() {
+  DisconnectAPI();
+  Socket->Close();
 }
 
-void UWebSocketHandler::SetToken(const FString& NewToken)
-{
-	UE_LOG(LogTemp, Log, TEXT("[UWebSocketHandler::SetToken]: Setting token: %s"), *NewToken);
-	this->Token = NewToken;
+void UWebSocketHandler::SendMessage(const FString &Action,
+                                    TSharedPtr<FJsonObject> JsonBody) const {
+  if (!JsonBody.IsValid()) {
+    JsonBody = MakeShareable(new FJsonObject());
+  }
+  JsonBody->SetStringField("action", Action);
+  JsonBody->SetStringField("token", Token);
 
-	if (NewToken != "")
-	{
-		bIsConnected = true;
-		SendMessage("GetEntities", nullptr);
-	}
-	else
-		bIsConnected = false;
+  FString OutputString;
+  if (const TSharedRef<TJsonWriter<>> Writer =
+          TJsonWriterFactory<>::Create(&OutputString);
+      FJsonSerializer::Serialize(JsonBody.ToSharedRef(), Writer)) {
+    Socket->Send(OutputString);
+    UE_LOG(LogTemp, Log,
+           TEXT("[UWebSocketHandler::SendMessage]: JSON message sent: %s"),
+           *OutputString);
+  } else {
+    UE_LOG(LogTemp, Error,
+           TEXT("[UWebSocketHandler::SendMessage]: Failed to serialize JSON"));
+  }
 }
 
-void UWebSocketHandler::SaveInstanceState() const
-{
-	USaveEntityState* SaveGameInstance = Cast<USaveEntityState>(UGameplayStatics::CreateSaveGameObject(USaveEntityState::StaticClass()));
+void UWebSocketHandler::SetToken(const FString &NewToken) {
+  UE_LOG(LogTemp, Log, TEXT("[UWebSocketHandler::SetToken]: Setting token: %s"),
+         *NewToken);
+  this->Token = NewToken;
 
-	SaveGameInstance->bIsRegistered = bIsRegistered;
-	UE_LOG(LogTemp, Log, TEXT("[UAIComponent::SaveEntityState]: bIsRegistered value: %s"), bIsRegistered ? TEXT("true") : TEXT("false"));
-
-	if (UGameplayStatics::SaveGameToSlot(SaveGameInstance, "GameInstance", 0))
-	{
-		UE_LOG(LogTemp, Log, TEXT("[UAIComponent::SaveEntityState]: Game saved successfully on slot: GameInstance"));
-	}
+  if (NewToken != "") {
+    bIsConnected = true;
+    SendMessage("GetEntities", nullptr);
+  } else
+    bIsConnected = false;
 }
 
-void UWebSocketHandler::LoadInstanceState()
-{
-	UE_LOG(LogTemp, Log, TEXT("[UAIComponent::LoadEntityState]: Try loading data for slot = GameInstance"));
-	if (UGameplayStatics::DoesSaveGameExist("GameInstance", 0))
-	{
-		if (const USaveEntityState* LoadedGame = Cast<USaveEntityState>(UGameplayStatics::LoadGameFromSlot("GameInstance", 0)))
-		{
-			bIsRegistered = LoadedGame->bIsRegistered;
-		}
-	}
+void UWebSocketHandler::SaveInstanceState() const {
+  USaveEntityState *SaveGameInstance = Cast<USaveEntityState>(
+      UGameplayStatics::CreateSaveGameObject(USaveEntityState::StaticClass()));
+
+  SaveGameInstance->bIsRegistered = bIsRegistered;
+  UE_LOG(LogTemp, Log,
+         TEXT("[UAIComponent::SaveEntityState]: bIsRegistered value: %s"),
+         bIsRegistered ? TEXT("true") : TEXT("false"));
+
+  if (UGameplayStatics::SaveGameToSlot(SaveGameInstance, "GameInstance", 0)) {
+    UE_LOG(LogTemp, Log,
+           TEXT("[UAIComponent::SaveEntityState]: Game saved successfully on "
+                "slot: GameInstance"));
+  }
 }
 
-void UWebSocketHandler::RegisterEntity(const FString& Checksum, const FString& ID) const
-{
-	RegisteredEntities->Emplace(Checksum, ID);
-	UE_LOG(LogTemp, Log, TEXT("[UAIComponent::HandleWebSocketMessage]: Registered entity %s on id : %s"), *Checksum, *ID);
+void UWebSocketHandler::LoadInstanceState() {
+  UE_LOG(LogTemp, Log,
+         TEXT("[UAIComponent::LoadEntityState]: Try loading data for slot = "
+              "GameInstance"));
+  if (UGameplayStatics::DoesSaveGameExist("GameInstance", 0)) {
+    if (const USaveEntityState *LoadedGame = Cast<USaveEntityState>(
+            UGameplayStatics::LoadGameFromSlot("GameInstance", 0))) {
+      bIsRegistered = LoadedGame->bIsRegistered;
+    }
+  }
 }
 
-void UWebSocketHandler::RegisterEntityOnApi(const FString &Name, const FString &Prompt, const FString &Checksum, const FString &Role) const
-{
-	const TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
-	JsonBody->SetStringField("name", Name);
-	JsonBody->SetStringField("prompt", Prompt);
-	JsonBody->SetStringField("checksum", Checksum);
-	JsonBody->SetStringField("role", Role);
-	SendMessage("CreateEntity", JsonBody);
+void UWebSocketHandler::RegisterEntity(const FString &Checksum,
+                                       const FString &ID) const {
+  RegisteredEntities->Emplace(Checksum, ID);
+  UE_LOG(LogTemp, Log,
+         TEXT("[UAIComponent::HandleWebSocketMessage]: Registered entity %s on "
+              "id : %s"),
+         *Checksum, *ID);
 }
 
-
-void UWebSocketHandler::RegisterAPI() const
-{
-	const TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
-	JsonBody->SetStringField("API_KEY", "VDCAjPZ8jhDmXfsSufW2oZyU8SFZi48dRhA8zyKUjSRU3T1aBZ7E8FFIjdEM2X1d");
-	JsonBody->SetStringField("identifier", "UserPlugin");
-	JsonBody->SetStringField("password", "password");
-	JsonBody->SetStringField("game_prompt", "You are playing a turn-based social deduction game: **Werewolf**. Goal: Identify the werewolves while protecting the innocent. Make decisions and statements based on that. At each turn, analyze the discussion and try to deduce who could be a werewolf. Do not forget this goal. Roleplay is secondary.");
-	SendMessage("Register", JsonBody);
+void UWebSocketHandler::RegisterEntityOnApi(const FString &Name,
+                                            const FString &Prompt,
+                                            const FString &Checksum,
+                                            const FString &Role) const {
+  const TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
+  JsonBody->SetStringField("name", Name);
+  JsonBody->SetStringField("prompt", Prompt);
+  JsonBody->SetStringField("checksum", Checksum);
+  JsonBody->SetStringField("role", Role);
+  SendMessage("CreateEntity", JsonBody);
 }
 
-void UWebSocketHandler::ConnectAPI() const
-{
-	const TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
-	JsonBody->SetStringField("identifier", "UserPlugin");
-	JsonBody->SetStringField("password", "password");
-	SendMessage("Connect", JsonBody);
+void UWebSocketHandler::RegisterAPI() const {
+  const TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
+  JsonBody->SetStringField(
+      "API_KEY",
+      "VDCAjPZ8jhDmXfsSufW2oZyU8SFZi48dRhA8zyKUjSRU3T1aBZ7E8FFIjdEM2X1d");
+  JsonBody->SetStringField("identifier", "UserPlugin");
+  JsonBody->SetStringField("password", "password");
+  JsonBody->SetStringField(
+      "game_prompt",
+      "You are playing a turn-based social deduction game: **Werewolf**. Goal: "
+      "Identify the werewolves while protecting the innocent. Make decisions "
+      "and statements based on that. At each turn, analyze the discussion and "
+      "try to deduce who could be a werewolf. Do not forget this goal. "
+      "Roleplay is secondary.");
+  SendMessage("Register", JsonBody);
 }
 
+void UWebSocketHandler::ConnectAPI() const {
+  const TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
+  JsonBody->SetStringField("identifier", "UserPlugin");
+  JsonBody->SetStringField("password", "password");
+  SendMessage("Connect", JsonBody);
+}
 
-void UWebSocketHandler::DisconnectAPI()
-{
-	TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
-	SendMessage("Disconnect", JsonBody);
-	SetToken("");
+void UWebSocketHandler::DisconnectAPI() {
+  TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
+  SendMessage("Disconnect", JsonBody);
+  SetToken("");
 }

--- a/Source/NPCForge/Public/WebSocketHandler.h
+++ b/Source/NPCForge/Public/WebSocketHandler.h
@@ -4,64 +4,72 @@
 
 #include "CoreMinimal.h"
 
-#include "WebSocketsModule.h"
 #include "IWebSocket.h"
-#include "SaveEntityState.h"
 #include "Kismet/GameplayStatics.h"
+#include "SaveEntityState.h"
+#include "WebSocketsModule.h"
 
 #include "WebSocketHandler.generated.h"
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnWebSocketMessageReceived, const FString&, Message);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnWebSocketMessageReceived,
+                                            const FString &, Message);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnWebSocketReady);
 
 UCLASS(Blueprintable)
-class NPCFORGE_API UWebSocketHandler : public UObject
-{
-	GENERATED_BODY()
+class NPCFORGE_API UWebSocketHandler : public UObject {
+  GENERATED_BODY()
 
 public:
-	UFUNCTION(BlueprintCallable, Category = "WebSocket")
-	void Initialize();
+  UFUNCTION(BlueprintCallable, Category = "WebSocket")
+  void Initialize();
 
-	UFUNCTION(BlueprintCallable, Category = "WebSocket")
-	void Close();
-	
-	void SendMessage(const FString& Action, TSharedPtr<FJsonObject> JsonBody) const;
+  UFUNCTION(BlueprintCallable, Category = "WebSocket")
+  void Close();
 
-	void ConnectAPI() const;
-	void RegisterAPI() const;
-	void DisconnectAPI();
-	
-	void RegisterEntity(const FString& Checksum, const FString& ID) const;
-	void RegisterEntityOnApi(const FString &Name, const FString &Prompt, const FString &Checksum, const FString &Role) const;
-	
-	void SetToken(const FString& NewToken);
+  UFUNCTION(BlueprintCallable, Category = "WebSocket")
+  void Ping();
 
-	void SaveInstanceState() const;
-	void LoadInstanceState();
+  void SendMessage(const FString &Action,
+                   TSharedPtr<FJsonObject> JsonBody) const;
 
-	void HandleReceivedMessage(const FString &Message);
+  void ConnectAPI() const;
+  void RegisterAPI() const;
+  void DisconnectAPI();
 
-	bool IsEntityRegistered(const FString &Checksum) const;
+  void RegisterEntity(const FString &Checksum, const FString &ID) const;
+  void RegisterEntityOnApi(const FString &Name, const FString &Prompt,
+                           const FString &Checksum, const FString &Role) const;
 
-	TSet<FString> MessagesSent;
+  void SetToken(const FString &NewToken);
 
-	UPROPERTY(BlueprintAssignable, Category = "WebSocket")
-	FOnWebSocketMessageReceived OnMessageReceived;
+  void SaveInstanceState() const;
+  void LoadInstanceState();
 
-	UPROPERTY(BlueprintAssignable, Category = "WebSocket")
-	FOnWebSocketReady OnReady;
-	
-	bool bIsRegistered = false;
-	bool bIsConnected = false;
+  void HandleReceivedMessage(const FString &Message);
 
-	int ApiUserID = -1;
+  bool IsEntityRegistered(const FString &Checksum) const;
+
+  TSet<FString> MessagesSent;
+
+  UPROPERTY(BlueprintAssignable, Category = "WebSocket")
+  FOnWebSocketMessageReceived OnMessageReceived;
+
+  UPROPERTY(BlueprintAssignable, Category = "WebSocket")
+  FOnWebSocketReady OnReady;
+
+  bool bIsRegistered = false;
+  bool bIsConnected = false;
+
+  int ApiUserID = -1;
+
 private:
-	const FString ServerURL = TEXT("ws://127.0.0.1:3000/ws");
-	const FString ServerProtocol = TEXT("ws");
-	FString Token = TEXT("");
+  const FString ServerURL = TEXT("ws://127.0.0.1:3000/ws");
+  const FString ServerProtocol = TEXT("ws");
+  FString Token = TEXT("");
 
-	TSharedPtr<TMap<FString, FString>> RegisteredEntities = MakeShareable(new TMap<FString, FString>());
+  TSharedPtr<TMap<FString, FString>> RegisteredEntities =
+      MakeShareable(new TMap<FString, FString>());
 
-	TSharedPtr<IWebSocket> Socket = FWebSocketsModule::Get().CreateWebSocket(ServerURL, ServerProtocol);
+  TSharedPtr<IWebSocket> Socket =
+      FWebSocketsModule::Get().CreateWebSocket(ServerURL, ServerProtocol);
 };


### PR DESCRIPTION
## Summary
- Reconnect to the server when the WebSocket closes or encounters an error
- On connection, trigger API registration or connection to reload entities
- Add Ping utility that reconnects and refreshes registration when needed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f7670294832d83594f62d65a40c2