### PR TITLE
Replace WebSocket ping with send-based keepalive

### DIFF
--- a/Source/NPCForge/Private/WebSocketHandler.cpp
+++ b/Source/NPCForge/Private/WebSocketHandler.cpp
@@ -217,16 +217,33 @@ void UWebSocketHandler::RegisterAPI() const
 
 void UWebSocketHandler::ConnectAPI() const
 {
-	const TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
-	JsonBody->SetStringField("identifier", "UserPlugin");
-	JsonBody->SetStringField("password", "password");
-	SendMessage("Connect", JsonBody);
+        const TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
+        JsonBody->SetStringField("identifier", "UserPlugin");
+        JsonBody->SetStringField("password", "password");
+        SendMessage("Connect", JsonBody);
+}
+
+
+void UWebSocketHandler::Ping()
+{
+       if (!Socket.IsValid())
+       {
+               return;
+       }
+
+       if (!Socket->IsConnected())
+       {
+               Socket->Connect();
+               return;
+       }
+
+       Socket->Send(TEXT("ping"));
 }
 
 
 void UWebSocketHandler::DisconnectAPI()
 {
-	TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
-	SendMessage("Disconnect", JsonBody);
+        TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
+        SendMessage("Disconnect", JsonBody);
 	SetToken("");
 }

--- a/Source/NPCForge/Public/WebSocketHandler.h
+++ b/Source/NPCForge/Public/WebSocketHandler.h
@@ -20,11 +20,14 @@ class NPCFORGE_API UWebSocketHandler : public UObject
 	GENERATED_BODY()
 
 public:
-	UFUNCTION(BlueprintCallable, Category = "WebSocket")
-	void Initialize();
+        UFUNCTION(BlueprintCallable, Category = "WebSocket")
+        void Initialize();
 
-	UFUNCTION(BlueprintCallable, Category = "WebSocket")
-	void Close();
+        UFUNCTION(BlueprintCallable, Category = "WebSocket")
+        void Close();
+
+       UFUNCTION(BlueprintCallable, Category = "WebSocket")
+       void Ping();
 	
 	void SendMessage(const FString& Action, TSharedPtr<FJsonObject> JsonBody) const;
 


### PR DESCRIPTION
## Summary
- add blueprint-callable Ping method
- use application-level ping message and reconnect when socket is lost

## Testing
- `g++ -c Source/NPCForge/Private/WebSocketHandler.cpp` *(fails: WebSocketHandler.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f934b4b0832d928638ddced71f05