### PR TITLE
Handle restart by reconnecting and re-registering

### DIFF
--- a/Source/NPCForge/Private/AIComponentSrc/AIComponent.cpp
+++ b/Source/NPCForge/Private/AIComponentSrc/AIComponent.cpp
@@ -67,15 +67,18 @@ void UAIComponent::CheckGameRole()
 
 void UAIComponent::OnWebsocketReady()
 {
-	RoleCheckElapsed = 0.0f;
-	
-	GetWorld()->GetTimerManager().SetTimer(
-		RoleCheckTimerHandle,
-		this,
-		&UAIComponent::CheckGameRole,
-		0.2f,
-		true
-	);
+        RoleCheckElapsed = 0.0f;
+        bIsWebsocketConnected = false;
+        bIsBusy = false;
+        TimeSinceLastDecision = 0.0f;
+
+        GetWorld()->GetTimerManager().SetTimer(
+                RoleCheckTimerHandle,
+                this,
+                &UAIComponent::CheckGameRole,
+                0.2f,
+                true
+        );
 }
 
 

--- a/Source/NPCForge/Private/WebSocketHandler.cpp
+++ b/Source/NPCForge/Private/WebSocketHandler.cpp
@@ -105,14 +105,14 @@ void UWebSocketHandler::HandleReceivedMessage(const FString &Message)
 						UE_LOG(LogTemp, Log, TEXT("[UAIComponent::HandleWebSocketMessage]: Handle CreateEntity Logic"));
 						RegisterEntity(JsonObject->GetStringField(TEXT("checksum")), JsonObject->GetStringField(TEXT("id")));
 					}
-					else if (Value == "Restart")
-					{
-							UE_LOG(LogTemp, Log, TEXT("[UAIComponent::HandleWebSocketMessage]: Handle Restart Logic"));
-							Close();
-					} else
-					{
-							OnMessageReceived.Broadcast(Message);
-					}
+                                        else if (Value == "Restart")
+                                        {
+                                                       UE_LOG(LogTemp, Log, TEXT("[UAIComponent::HandleWebSocketMessage]: Handle Restart Logic"));
+                                                       Restart();
+                                        } else
+                                        {
+                                                        OnMessageReceived.Broadcast(Message);
+                                        }
 				}
 			}
 		}
@@ -231,13 +231,24 @@ void UWebSocketHandler::ConnectAPI() const
 
 void UWebSocketHandler::DisconnectAPI()
 {
-	TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
-	SendMessage("Disconnect", JsonBody);
-	SetToken("");
+        TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
+        SendMessage("Disconnect", JsonBody);
+        SetToken("");
 }
 
 void UWebSocketHandler::Restart()
 {
-	TSharedPtr<FJsonObject> JsonBody = MakeShareable(new FJsonObject());
-	SendMessage("Restart", JsonBody);
+        UE_LOG(LogTemp, Log, TEXT("[UWebSocketHandler::Restart]: Restarting connection"));
+
+        // Close existing connection and reset state
+        Close();
+        RegisteredEntities->Empty();
+        MessagesSent.Empty();
+
+        // Recreate and initialize the socket
+        Socket = FWebSocketsModule::Get().CreateWebSocket(ServerURL, ServerProtocol);
+        Initialize();
+
+        // Reconnect to the API
+        ConnectAPI();
 }


### PR DESCRIPTION
## Summary
- Restart the WebSocket connection when receiving a `Restart` message
- Clear registered state and reconnect to the API for a fresh session
- Reset AI components so entities re-register as on initial launch

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8563deaa0832db43761c25c971583