### PR TITLE
Track voting phase to prevent duplicate AI votes

### DIFF
--- a/Source/NPCForge/Private/AIComponentSrc/AIComponent.cpp
+++ b/Source/NPCForge/Private/AIComponentSrc/AIComponent.cpp
@@ -1,115 +1,116 @@
 ﻿#include "AIComponent.h"
 
-UAIComponent::UAIComponent()
-{
-	GameMode = nullptr;
-	WebSocketHandler = nullptr;
-	PrimaryComponentTick.bCanEverTick = true;
+UAIComponent::UAIComponent() {
+  GameMode = nullptr;
+  WebSocketHandler = nullptr;
+  PrimaryComponentTick.bCanEverTick = true;
 }
 
-void UAIComponent::BeginPlay()
-{
-	Super::BeginPlay();
+void UAIComponent::BeginPlay() {
+  Super::BeginPlay();
 
-	UE_LOG(LogTemp, Log, TEXT("[UAIComponent::BeginPlay]: %s joined the game!"), *UniqueName);
-	
-	if (const UWorld* World = GetOwner()->GetWorld())
-	{
-		if (auto* MyGI = Cast<UNPCForgeGameInstance>(World->GetGameInstance()))
-		{
-			if (!WebSocketHandler)
-			{
-				WebSocketHandler = MyGI->GetWebSocketHandler();
-				WebSocketHandler->OnMessageReceived.AddDynamic(this, &UAIComponent::HandleWebSocketMessage);
-				WebSocketHandler->OnReady.AddDynamic(this, &UAIComponent::OnWebsocketReady);
-			}
-		} else
-		{
-			UE_LOG(LogTemp, Warning, TEXT("Not Found Game Instance"));
-		}
-	}
+  UE_LOG(LogTemp, Log, TEXT("[UAIComponent::BeginPlay]: %s joined the game!"),
+         *UniqueName);
 
-	GameMode = Cast<AMyGameMode>(GetWorld()->GetAuthGameMode());
+  if (const UWorld *World = GetOwner()->GetWorld()) {
+    if (auto *MyGI = Cast<UNPCForgeGameInstance>(World->GetGameInstance())) {
+      if (!WebSocketHandler) {
+        WebSocketHandler = MyGI->GetWebSocketHandler();
+        WebSocketHandler->OnMessageReceived.AddDynamic(
+            this, &UAIComponent::HandleWebSocketMessage);
+        WebSocketHandler->OnReady.AddDynamic(this,
+                                             &UAIComponent::OnWebsocketReady);
+      }
+    } else {
+      UE_LOG(LogTemp, Warning, TEXT("Not Found Game Instance"));
+    }
+  }
+
+  GameMode = Cast<AMyGameMode>(GetWorld()->GetAuthGameMode());
 }
 
-void UAIComponent::CheckGameRole()
-{
-	RoleCheckElapsed += 0.2f;
-	
-	if (AActor* Owner = GetOwner();
-		Owner && Owner->GetClass()->ImplementsInterface(UAIInterface::StaticClass()))
-	{
-		if (FString Role = IAIInterface::Execute_GetGameRole(Owner);
-			Role != "None")
-		{
-			CachedRole = Role;
-			UE_LOG(LogTemp, Warning, TEXT("Final Role: %s"), *Role);
-			GetWorld()->GetTimerManager().ClearTimer(RoleCheckTimerHandle);
+void UAIComponent::CheckGameRole() {
+  RoleCheckElapsed += 0.2f;
 
-			const FString CombinedString = FString::Printf(TEXT("%s%s%d"), *UniqueName, *PersonalityPrompt, WebSocketHandler->ApiUserID);
-			EntityChecksum = FMD5::HashAnsiString(*CombinedString);
-	
-			if (!WebSocketHandler->IsEntityRegistered(EntityChecksum)) {
-				WebSocketHandler->RegisterEntityOnApi(UniqueName, PersonalityPrompt, EntityChecksum, CachedRole);
-			}
-			bIsWebsocketConnected = true;
-			
-			return;
-		}
-	}
+  if (AActor *Owner = GetOwner();
+      Owner &&
+      Owner->GetClass()->ImplementsInterface(UAIInterface::StaticClass())) {
+    if (FString Role = IAIInterface::Execute_GetGameRole(Owner);
+        Role != "None") {
+      CachedRole = Role;
+      UE_LOG(LogTemp, Warning, TEXT("Final Role: %s"), *Role);
+      GetWorld()->GetTimerManager().ClearTimer(RoleCheckTimerHandle);
 
-	if (RoleCheckElapsed >= 10.0f)
-	{
-		UE_LOG(LogTemp, Error, TEXT("Timeout waiting for GetGameRole() != None"));
-		GetWorld()->GetTimerManager().ClearTimer(RoleCheckTimerHandle);
-	}
+      const FString CombinedString =
+          FString::Printf(TEXT("%s%s%d"), *UniqueName, *PersonalityPrompt,
+                          WebSocketHandler->ApiUserID);
+      EntityChecksum = FMD5::HashAnsiString(*CombinedString);
+
+      if (!WebSocketHandler->IsEntityRegistered(EntityChecksum)) {
+        WebSocketHandler->RegisterEntityOnApi(UniqueName, PersonalityPrompt,
+                                              EntityChecksum, CachedRole);
+      }
+      bIsWebsocketConnected = true;
+
+      return;
+    }
+  }
+
+  if (RoleCheckElapsed >= 10.0f) {
+    UE_LOG(LogTemp, Error, TEXT("Timeout waiting for GetGameRole() != None"));
+    GetWorld()->GetTimerManager().ClearTimer(RoleCheckTimerHandle);
+  }
 }
 
-void UAIComponent::OnWebsocketReady()
-{
-	RoleCheckElapsed = 0.0f;
-	
-	GetWorld()->GetTimerManager().SetTimer(
-		RoleCheckTimerHandle,
-		this,
-		&UAIComponent::CheckGameRole,
-		0.2f,
-		true
-	);
+void UAIComponent::OnWebsocketReady() {
+  RoleCheckElapsed = 0.0f;
+
+  GetWorld()->GetTimerManager().SetTimer(
+      RoleCheckTimerHandle, this, &UAIComponent::CheckGameRole, 0.2f, true);
 }
 
-
-void UAIComponent::TriggerSendMessageEvent(const FString Message, const FString Reasoning) const
-{
-	if (OnSendMessage.IsBound())
-	{
-		OnSendMessage.Broadcast(Message, Reasoning);
-	}
+void UAIComponent::TriggerSendMessageEvent(const FString Message,
+                                           const FString Reasoning) const {
+  if (OnSendMessage.IsBound()) {
+    OnSendMessage.Broadcast(Message, Reasoning);
+  }
 }
 
-void UAIComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
-{
-	Super::EndPlay(EndPlayReason);
+void UAIComponent::EndPlay(const EEndPlayReason::Type EndPlayReason) {
+  Super::EndPlay(EndPlayReason);
 }
 
-void UAIComponent::TickComponent(const float DeltaTime, const ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
-{
-	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
-	
-	if (!GetOwner()) return;
+void UAIComponent::TickComponent(
+    const float DeltaTime, const ELevelTick TickType,
+    FActorComponentTickFunction *ThisTickFunction) {
+  Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
 
-	TimeSinceLastDecision += DeltaTime;
-	
-	if (bIsWebsocketConnected && !bIsBusy && TimeSinceLastDecision >= DecisionInterval && CachedRole != "None")
-	{
-		bIsBusy = true;
-		TimeSinceLastDecision = 0.0f;
+  if (!GetOwner())
+    return;
 
-		const FString EnvironmentPrompt = ScanEnvironment();
+  FString CurrentPhase = GameMode ? GameMode->GetPhase() : FString();
+  if (CurrentPhase != LastKnownPhase) {
+    bHasVotedInCurrentPhase = false;
+    bIsBusy = false;
+    LastKnownPhase = CurrentPhase;
+  }
 
-		UE_LOG(LogTemp, Log, TEXT("Env = %s"), *EnvironmentPrompt)
-		
-		MakeDecision(EnvironmentPrompt);
-	}
+  TimeSinceLastDecision += DeltaTime;
 
+  if (bIsWebsocketConnected && !bIsBusy &&
+      TimeSinceLastDecision >= DecisionInterval && CachedRole != "None") {
+    bIsBusy = true;
+    TimeSinceLastDecision = 0.0f;
+
+    const FString EnvironmentPrompt = ScanEnvironment();
+
+    if (CurrentPhase == TEXT("Vote") && bHasVotedInCurrentPhase) {
+      bIsBusy = false;
+      return;
+    }
+
+    UE_LOG(LogTemp, Log, TEXT("Env = %s"), *EnvironmentPrompt)
+
+    MakeDecision(EnvironmentPrompt);
+  }
 }

--- a/Source/NPCForge/Private/AIComponentSrc/HandleDecision.cpp
+++ b/Source/NPCForge/Private/AIComponentSrc/HandleDecision.cpp
@@ -1,41 +1,40 @@
 ﻿#include "AIComponent.h"
 
-void UAIComponent::ParseChecksums(const FString& InputString, TArray<FString>& OutChecksums)
-{
-	FString TrimmedString = InputString;
-	TrimmedString.RemoveFromStart("[");
-	TrimmedString.RemoveFromEnd("]");
+void UAIComponent::ParseChecksums(const FString &InputString,
+                                  TArray<FString> &OutChecksums) {
+  FString TrimmedString = InputString;
+  TrimmedString.RemoveFromStart("[");
+  TrimmedString.RemoveFromEnd("]");
 
-	TrimmedString.ParseIntoArray(OutChecksums, TEXT(", "), true);
+  TrimmedString.ParseIntoArray(OutChecksums, TEXT(", "), true);
 }
 
-void UAIComponent::HandleDecision(const TSharedPtr<FJsonObject> &JsonObject)
-{
-	const FString Action = JsonObject->GetStringField(TEXT("Action"));
+void UAIComponent::HandleDecision(const TSharedPtr<FJsonObject> &JsonObject) {
+  const FString Action = JsonObject->GetStringField(TEXT("Action"));
 
-	UE_LOG(LogTemp, Log, TEXT("[UAIComponent::HandleDecision]: Action = %s"), *Action);
+  UE_LOG(LogTemp, Log, TEXT("[UAIComponent::HandleDecision]: Action = %s"),
+         *Action);
 
-	if (Action == TEXT("TalkTo"))
-	{
-		const FString Message = JsonObject->GetStringField(TEXT("Message"));
-		const FString Reasoning = JsonObject->GetStringField(TEXT("Reasoning"));
+  if (Action == TEXT("TalkTo")) {
+    const FString Message = JsonObject->GetStringField(TEXT("Message"));
+    const FString Reasoning = JsonObject->GetStringField(TEXT("Reasoning"));
 
-		if (const FString Target = JsonObject->GetStringField(TEXT("TalkTo"));
-			Target.Contains("Everyone"))
-		{
-			TriggerSendMessageEvent(Message, Reasoning);
-			bIsBusy = false;
-		} else
-		{
-			UE_LOG(LogTemp, Error, TEXT("[UAIComponent::HandleDecision]: Message is not for everyone"));
-		}
-	} else if (Action == TEXT("VoteFor"))
-	{
-		const FString Target = JsonObject->GetStringField(TEXT("VoteFor"));
-		UE_LOG(LogTemp, Log, TEXT("%s vote for %s"), *UniqueName, *Target)
-		OnVote.Broadcast(*UniqueName, *Target);
-	} else
-	{
-		UE_LOG(LogTemp, Error, TEXT("Action not found"));
-	}
+    if (const FString Target = JsonObject->GetStringField(TEXT("TalkTo"));
+        Target.Contains("Everyone")) {
+      TriggerSendMessageEvent(Message, Reasoning);
+      bIsBusy = false;
+    } else {
+      UE_LOG(
+          LogTemp, Error,
+          TEXT("[UAIComponent::HandleDecision]: Message is not for everyone"));
+    }
+  } else if (Action == TEXT("VoteFor")) {
+    const FString Target = JsonObject->GetStringField(TEXT("VoteFor"));
+    UE_LOG(LogTemp, Log, TEXT("%s vote for %s"), *UniqueName, *Target)
+    OnVote.Broadcast(*UniqueName, *Target);
+    bHasVotedInCurrentPhase = true;
+    bIsBusy = false;
+  } else {
+    UE_LOG(LogTemp, Error, TEXT("Action not found"));
+  }
 }

--- a/Source/NPCForge/Public/AIComponent.h
+++ b/Source/NPCForge/Public/AIComponent.h
@@ -1,100 +1,109 @@
 ﻿#pragma once
 
-#include "CoreMinimal.h"
-#include "Components/ActorComponent.h"
-#include "WebSocketHandler.h"
-#include "SaveEntityState.h"
-#include "Kismet/GameplayStatics.h"
-#include "JsonObjectConverter.h"
 #include "AIController.h"
+#include "AIInterface.h"
+#include "Components/ActorComponent.h"
+#include "CoreMinimal.h"
 #include "Dom/JsonObject.h"
+#include "JsonObjectConverter.h"
+#include "Kismet/GameplayStatics.h"
+#include "MyGameMode.h"
+#include "NPCForgeGameInstance.h"
+#include "SaveEntityState.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
-#include "NPCForgeGameInstance.h"
-#include "AIInterface.h"
-#include "MyGameMode.h"
+#include "WebSocketHandler.h"
 
 #include "AIComponent.generated.h"
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnSendMessage, FString, Message, FString, Reasoning);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnVote, FString, Voter, FString, VoteTarget);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnSendMessage, FString, Message,
+                                             FString, Reasoning);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnVote, FString, Voter, FString,
+                                             VoteTarget);
 
-UCLASS(ClassGroup=(AI), meta=(BlueprintSpawnableComponent, DisplayName="NPCForge", ToolTip="Mark as NPC"))
-class NPCFORGE_API UAIComponent : public UActorComponent
-{
-	GENERATED_BODY()
+UCLASS(ClassGroup = (AI),
+       meta = (BlueprintSpawnableComponent, DisplayName = "NPCForge",
+               ToolTip = "Mark as NPC"))
+class NPCFORGE_API UAIComponent : public UActorComponent {
+  GENERATED_BODY()
 
 public:
-	// Base Class
-	UAIComponent();
-	
-	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
-	
-	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+  // Base Class
+  UAIComponent();
 
-	// Display Chat
-	UPROPERTY(BlueprintAssignable, Category="Events")
-	FOnSendMessage OnSendMessage;
+  virtual void
+  TickComponent(float DeltaTime, ELevelTick TickType,
+                FActorComponentTickFunction *ThisTickFunction) override;
 
-	// Voting
-	UPROPERTY(BlueprintAssignable, Category="Events")
-	FOnVote OnVote;
+  virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
-	UFUNCTION(BlueprintCallable, Category="MyComponent")
-	void TriggerSendMessageEvent(const FString Message, const FString Reasoning) const;
-	
-	// Properties
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	FString PersonalityPrompt;
+  // Display Chat
+  UPROPERTY(BlueprintAssignable, Category = "Events")
+  FOnSendMessage OnSendMessage;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	FString UniqueName;
+  // Voting
+  UPROPERTY(BlueprintAssignable, Category = "Events")
+  FOnVote OnVote;
 
-	FString EntityChecksum;
+  UFUNCTION(BlueprintCallable, Category = "MyComponent")
+  void TriggerSendMessageEvent(const FString Message,
+                               const FString Reasoning) const;
 
+  // Properties
+  UPROPERTY(EditAnywhere, BlueprintReadWrite)
+  FString PersonalityPrompt;
 
-	// Environment Discovering
-	FString ScanEnvironment();
+  UPROPERTY(EditAnywhere, BlueprintReadWrite)
+  FString UniqueName;
 
-	FString GetPhase();
+  FString EntityChecksum;
 
-	FString ScanForNearbyEntities(const float Radius, const FVector &ScanLocation) const;
+  // Environment Discovering
+  FString ScanEnvironment();
 
+  FString GetPhase();
 
-	// WebSocket Communication
-	UFUNCTION()
-	void HandleWebSocketMessage(const FString& JsonString);
+  FString ScanForNearbyEntities(const float Radius,
+                                const FVector &ScanLocation) const;
 
-	UFUNCTION()
-	void OnWebsocketReady();
+  // WebSocket Communication
+  UFUNCTION()
+  void HandleWebSocketMessage(const FString &JsonString);
 
-	void MakeDecision(const FString& Prompt) const;
-	void HandleDecision(const TSharedPtr<FJsonObject> &JsonObject);
-	
-	static void ParseChecksums(const FString& InputString, TArray<FString>& OutChecksums);
+  UFUNCTION()
+  void OnWebsocketReady();
 
-	void CheckGameRole();
-	
+  void MakeDecision(const FString &Prompt) const;
+  void HandleDecision(const TSharedPtr<FJsonObject> &JsonObject);
+
+  static void ParseChecksums(const FString &InputString,
+                             TArray<FString> &OutChecksums);
+
+  void CheckGameRole();
+
 protected:
-	// Base Class
-	virtual void BeginPlay() override;
+  // Base Class
+  virtual void BeginPlay() override;
 
 private:
-	float TimeSinceLastDecision = 0.0f;
-	float DecisionInterval = 5.0f;
+  float TimeSinceLastDecision = 0.0f;
+  float DecisionInterval = 5.0f;
 
-	FTimerHandle RoleCheckTimerHandle;
-	float RoleCheckElapsed = 0.0f;
-	FString CachedRole = "None";
+  FTimerHandle RoleCheckTimerHandle;
+  float RoleCheckElapsed = 0.0f;
+  FString CachedRole = "None";
 
-	AMyGameMode *GameMode;
+  AMyGameMode *GameMode;
 
-	FTimerHandle ResponseTimerHandle;
-	
-	// Attributes
-	UWebSocketHandler* WebSocketHandler;
-	// bool bIsRegistered = false;
-	bool bIsWebsocketConnected = false;
+  FTimerHandle ResponseTimerHandle;
 
-	bool bIsBusy = false;
+  // Attributes
+  UWebSocketHandler *WebSocketHandler;
+  // bool bIsRegistered = false;
+  bool bIsWebsocketConnected = false;
+
+  bool bIsBusy = false;
+
+  bool bHasVotedInCurrentPhase = false;
+  FString LastKnownPhase;
 };


### PR DESCRIPTION
## Summary
- Track last known game phase and whether the AI has voted in the current phase
- Reset vote state on phase changes and skip decisions after voting
- Mark vote and clear busy state when broadcasting a vote

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bee0fd7678832d9c2a18dba22bb0e2